### PR TITLE
Mitigating ERC20 Approval Race Condition

### DIFF
--- a/contracts/MystToken.sol
+++ b/contracts/MystToken.sol
@@ -100,6 +100,16 @@ contract MystToken is Context, IERC20, IUpgradeAgent {
         return true;
     }
 
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
     /**
      * ERC2612 `permit`: 712-signed token approvals
      */


### PR DESCRIPTION
Adding `increaseAllowance` and `decreaseAllowance` functions so users could avoid approval race conditions.

For smart contracts we're recommending to use `safeApprove` from OpenZeppling SafeERC20 library. Or using approve of uint(-1) to add permission of using tokens and approve of 0 for deleting such permission. Same for `permit` users.